### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Bump `lib-util` to the next-major SNAPSHOT published from master after the lib's XP 8 upgrade. We are not yet releasing the new majors — consumers pin directly to the SNAPSHOTs, which resolve from the existing `xp.enonicRepo('dev')` declaration.

## Versions bumped

| Library | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` (resolves from `xp.enonicRepo('dev')`) |

## Excludes

No `exclude` clauses were present on any of the bumped lib dependencies (or anywhere else in `build.gradle`/`settings.gradle`) — nothing to remove or re-justify.

## Snapshot repo

`xp.enonicRepo('dev')` is already declared in the root `build.gradle` `repositories {}` block; no addition needed.

## Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration include` — `lib-util:4.0.0-SNAPSHOT` resolves cleanly with no transitive conflicts.
- Runtime verification (deploying the app to a running XP 8 instance) was **not** performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)