### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = demo.morse.chat
 appName = com.enonic.app.demo.morse.chat
 xpVersion=8.0.0-B4
-version=1.3.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Branch out the XP 7 maintenance line on `1.x` (created from tag `v1.2.0`) and bump master to `2.0.0-SNAPSHOT`.
- Configure `enonic/release-tools/build-and-publish` to treat both `master` and `1.x` as release branches so pushes to either branch publish releases.

A companion PR will be opened against `1.x` to add the same `releaseBranch:` block to its own copy of the workflow file (the action reads it from the workflow on the branch where the push occurred).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a CI run on `master` continues to publish artifacts cleanly via `enonic/release-tools/build-and-publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)