### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/enonic-gradle.yml` on the `1.x` maintenance branch with a `releaseBranch:` block listing both `master` and `1.x`.
- Required so pushes to `1.x` trigger publishing — the `enonic/release-tools/build-and-publish` action reads `releaseBranch:` from the workflow file on the branch where the push occurred. Without this PR, `1.x` would never classify as release-eligible.

The corresponding master-side change (version bump and the same `releaseBranch:` block) is in #47.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a future version-bump push to `1.x` is recognized as a release branch by `enonic/release-tools/build-and-publish` (action's `release` output becomes `'true'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)