### PR TITLE
Drop unused lib-util dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     include xplibs.portal
     include xplibs.websocket
     include libs.lib.thymeleaf
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }


### PR DESCRIPTION
## Summary

`lib-util` was declared in `gradle/libs.versions.toml` and pulled in via `build.gradle` but never actually used — no `require('/lib/util')` calls anywhere in `src/`.

Drops the dead dep:
- `build.gradle` — `include libs.lib.util`
- `gradle/libs.versions.toml` — `util` version + `lib-util` library entries

No behavior change.

## Test plan

- [x] `./gradlew build` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)